### PR TITLE
added moderator actions service

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,8 +10,9 @@ import authRouter from "./src/auth/route/authRoutes.js";
 import articleRouter from "./src/tornadoArticles/routes/artcileRoutes.js";
 import categoryRoutes from "./src/tornadoCategories/routes/categoryRoutes.js";
 import topicRoutes from "./src/tornadoCategories/routes/topicRoutes.js";
-import TornadoUserRoutes from "./src/tornadoUser/routes/userRoutes.js";
+import tornadoUserRoutes from "./src/tornadoUser/routes/userRoutes.js";
 import APIError from "./util/APIError.js";
+import moderatorActionRoutes from "./src/tornadoPlatform/routes/moderatorActionRoutes.js";
 
 let app = express();
 
@@ -53,7 +54,10 @@ app.use("/api/v1", categoryRoutes);
 app.use("/api/v1", topicRoutes);
 
 // Users
-app.use("/api/v1", TornadoUserRoutes);
+app.use("/api/v1", tornadoUserRoutes);
+
+// Moderator actions
+app.use("/api/v1", moderatorActionRoutes);
 
 // Notifications
 // app.use('/api/v1/users/:userId/notifications')

--- a/config/settings.js
+++ b/config/settings.js
@@ -85,6 +85,9 @@ const ARTICLE_PREFERENCES_UPDATE_LIMIT = "3 minutes";
 // The cooldown for how many times the user can change tags for article's X
 const ARTICLE_TAGS_UPDATE_LIMIT = "5 minutes";
 
+// Warning period is used when user get a ban for some reason. so he get a warning of deleting account if he violate the rules in X days
+const BAN_WARNING_PERIOD = "1 month";
+
 // How many tokens the user can request at the same time to get first blcok time (5 minutes)
 const PASSWORD_TOKEN_ALLOWED_COUNTS = 5;
 
@@ -111,6 +114,15 @@ const GENERATE_EMAIL_CODES_LIMITS = [
 
 // May the roles grow in the future. But I've used them a lot so it's better for cache and use
 const TORNADO_ROLES = ["admin", "moderator", "user"];
+
+// When moderator take an action that will be stored in the database so this is the available actions for now
+const MODERATOR_ACTIONS = [
+    "warning",
+    "ban",
+    "delete account",
+    "delete article",
+    "other", // If moderator select this. he/she must explain everything in the reason
+];
 
 // In my recommendation system I will give score high priority over read counts
 // but also consider it in my equation. As artilces the reads aren't a good way to rank
@@ -171,6 +183,7 @@ export {
     ARTICLES_FOLLOWINGS_MIN_LIMIT,
     ARTICLES_TOPICS_MAX_LIMIT,
     ARTICLES_TOPICS_MIN_LIMIT,
+    BAN_WARNING_PERIOD,
     EMAIL_CODES_ALLOWED_COUNTS,
     GENERATE_EMAIL_CODES_LIMITS,
     GENERATE_PASSWORD_TOKENS_LIMITS,
@@ -183,6 +196,7 @@ export {
     MAX_TAGS_ARTICLE_COUNT,
     MAX_TOPICS_ARTICLE_COUNT,
     MIN_RESULTS,
+    MODERATOR_ACTIONS,
     PASSWORD_TOKEN_ALLOWED_COUNTS,
     PUBLISH_ARTICLE_LIMIT,
     SUPPORTED_ARTICLES_LANGUAGES,

--- a/config/snowFlake.js
+++ b/config/snowFlake.js
@@ -31,6 +31,8 @@ const flakeIdGenComment = new FlakeId({ epoch: customEpoch });
 
 const flakeIdGenCategory = new FlakeId({ epoch: customEpoch });
 
+const flakeIdGenPlatform = new FlakeId({epoch: customEpoch})
+
 /**
  * Generate new id for articls
  * @returns {number}
@@ -63,9 +65,18 @@ function generateSnowFlakeIdCategory() {
     return intFormat(flakeIdGenCategory.next());
 }
 
+/**
+ * Generate new id for any platform specific model such as FAQ or user activity...
+ * @returns {number}
+ */
+function generateSnowFlakeIdPlatform() {
+    return intFormat(flakeIdGenPlatform.next());
+}
+
 export {
     generateSnowFlakeIdArticle,
     generateSnowFlakeIdCategory,
     generateSnowFlakeIdComment,
     generateSnowFlakeIdUser,
+    generateSnowFlakeIdPlatform
 };

--- a/src/auth/controllers/signin.js
+++ b/src/auth/controllers/signin.js
@@ -91,7 +91,7 @@ async function signin(req, res, next) {
             // secure: true,
         });
 
-        sanitize(user, ["email", ["limits", "canGenForgetPassAt"]]);
+        sanitize(user, [["limits", "canGenForgetPassAt"]]);
 
         return res.status(200).json({
             success: true,

--- a/src/auth/controllers/signup.js
+++ b/src/auth/controllers/signup.js
@@ -28,7 +28,7 @@ async function signup(req, res, next) {
 
         let { fullName, email, password, birthDate, gender } = req?.body;
 
-        const user = await AuthUserService.createUser(
+        let user = await AuthUserService.createUser(
             fullName,
             email,
             password,
@@ -37,6 +37,9 @@ async function signup(req, res, next) {
             profilePicName,
             "user" // The role always user
         );
+
+        // Uniform the data shape when user signin in or signup
+        user = await AuthUserService.getUserBy(user.id, false);
 
         // Save the id
         userId = user.dataValues.id;
@@ -97,7 +100,7 @@ async function signup(req, res, next) {
         });
 
         // Delete some info
-        sanitize(user, ["email"]);
+        sanitize(user, [["limits", "canGenForgetPassAt"]]);
 
         // TODO: Send a notifitcation asking for verify the email
 
@@ -105,7 +108,8 @@ async function signup(req, res, next) {
         res.status(200).json({
             success: true,
             data: user,
-            message: "Please verify your email to be able to interact with Tornado Articles website"
+            message:
+                "Please verify your email to be able to interact with Tornado Articles website",
         });
     } catch (err) {
         // When facing the error the photo now in the dist. Delete it

--- a/src/auth/middlewares/logoutDevice.validate.js
+++ b/src/auth/middlewares/logoutDevice.validate.js
@@ -21,7 +21,7 @@ async function logoutDeviceValidate(req, res, next) {
         const { deviceName = null } = req?.query ?? {};
 
         if (deviceName === null)
-            return next(GlobalErrorsEnum.MISSING_FIELD("device name"));
+            return next(GlobalErrorsEnum.MISSING_FIELD("deviceName"));
 
         // By the way we don't use real devices names but assusming we use it
         const DeviceName = string().trim().min(1).max(255); // Assuming there is a device with that name

--- a/src/auth/route/authRoutes.js
+++ b/src/auth/route/authRoutes.js
@@ -27,6 +27,7 @@ import validateSignin from "../middlewares/signin.validate.js";
 import validateSignup from "../middlewares/signup.validate.js";
 import validateSession from "../middlewares/validateSession.js";
 import verifyEmailValidate from "../middlewares/verifyEmail.validate.js";
+import isModerator from "../../../publicMiddlewares/isModerator.js";
 
 const authRouter = Router();
 
@@ -87,12 +88,12 @@ authRouter.put(
 );
 
 
-// Admin can delete user account
+// (Admin/Moderator) can delete user account
 // Used POST becasue there is a body
 authRouter.post(
     "/auth/users/:userId/delete",
     isAuthenticated,
-    isAdmin,
+    isModerator,
     adminDeleteUserValidate,
     adminDeleteUser
 );

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -54,6 +54,9 @@ async function addAssociations() {
     const { default: ArticleLimit } = await import(
         "../tornadoArticles/models/articleLimit.js"
     );
+    const { default: ModeratorAction } = await import(
+        "../tornadoPlatform/models/moderatorAction.js"
+    );
 
     //////// Users Followings
     // Many to Many relationship between users (like user A get an array with who is following)
@@ -322,6 +325,18 @@ async function addAssociations() {
         foreignKey: "userId",
         otherKey: "articleId",
         onDelete: "SET NULL", // When user get deleted leave his score
+    });
+
+    ///////////// Users activities
+    User.hasMany(ModeratorAction, {
+        foreignKey: "userId",
+        onDelete: "SET NULL",
+        onUpdate: "CASCADE",
+    });
+    ModeratorAction.belongsTo(User, {
+        foreignKey: "userId",
+        onDelete: "SET NULL",
+        onUpdate: "CASCADE",
     });
 }
 

--- a/src/tornadoArticles/controllers/moderatorDeleteArticle.js
+++ b/src/tornadoArticles/controllers/moderatorDeleteArticle.js
@@ -10,22 +10,23 @@ import ArticleService from "../services/articleService.js";
 async function moderatorDeleteArticle(req, res, next) {
     try {
         const { articleId } = req?.params;
-        const { reason, userId } = req?.body;
+        const { userReason, reason, userId } = req?.body;
 
         // Get article details
         const article = await ArticleService.getArticleProps(articleId, [
             "title",
             "createdAt",
         ]);
-
-        // Delete the article without checking if it's belong to the user because this is MODERATOR
-        await ArticleService.deleteArticle(articleId);
-
+        
         // Get user details
         const user = await TornadoUserService.getUserProps(userId, [
+            "id",
             "email",
             "fullName",
         ]);
+
+        // Delete the article without checking if it's belong to the user because this is MODERATOR
+        await ArticleService.deleteArticle(articleId, user.id, user.email, user.fullName, reason);
 
         // TODO: send notification in Tornado platfrom
 
@@ -41,7 +42,7 @@ async function moderatorDeleteArticle(req, res, next) {
             {
                 createdAt: article.dataValues.createdAt,
                 title: article.dataValues.title,
-                reason,
+                userReason,
             }
         );
 

--- a/src/tornadoArticles/middlewares/getArticlesFor.validate.js
+++ b/src/tornadoArticles/middlewares/getArticlesFor.validate.js
@@ -5,11 +5,11 @@ import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
 
 class ErrorsEnum {
     static INVALID_DATE = () => {
-        const cachedErr = GlobalErrorsEnum.INVALID_DATATYPE("since", "date");
+        const cachedErr = GlobalErrorsEnum.INVALID_DATATYPE("since", "Date");
 
         // Use the same error but add hint
         cachedErr.additionalData.hint =
-            "Check if you are using correct format for ISO date string in the URL. in JavaScript something like URLSearchParams may help";
+            "Check if you are using correct format for ISO date string. and check if it's URL encoded. in JavaScript something like URLSearchParams may help";
         return cachedErr;
     };
 

--- a/src/tornadoArticles/middlewares/moderatorDeleteArticle.validate.js
+++ b/src/tornadoArticles/middlewares/moderatorDeleteArticle.validate.js
@@ -3,8 +3,8 @@ import APIError from "../../../util/APIError.js";
 import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
 
 class ErrorsEnum {
-    static TOO_LONG_REASON = new APIError(
-        "The reason's characters length should be 300 maximum",
+    static ALL_FIELDS_REQUIRED = new APIError(
+        "Provide 'userReason', 'userId' and 'reason' to store it in the activities",
         400,
         "VALIDATION_ERROR"
     );
@@ -17,29 +17,33 @@ class ErrorsEnum {
  */
 async function moderatorDeleteArticleValidate(req, res, next) {
     try {
-        let { reason = null, userId = null } = req?.body ?? {};
+        let {
+            userReason = null,
+            userId = null,
+            reason = null,
+        } = req?.body ?? {};
 
-        if (reason === null)
-            return next(GlobalErrorsEnum.MISSING_FIELD("reason"));
-
-        if (userId === null)
-            return next(GlobalErrorsEnum.MISSING_FIELD("userId"));
+        if (userReason === null || userId === null || reason === null)
+            return next(ErrorsEnum.ALL_FIELDS_REQUIRED);
 
         const Data = object({
-            reason: string(),
+            userReason: string().trim(),
             userId: string().regex(/^\d+$/),
+            reason: string(),
         });
 
         Object.assign(
             req.body,
             Data.parse({
+                userReason,
                 reason,
                 userId: String(userId),
             })
         );
 
-        // Check reason length
-        if (reason.length > 300) return next(ErrorsEnum.TOO_LONG_REASON);
+        // Check user reason length
+        if (userReason.length > 300 && userReason.length < 4)
+            return next(GlobalErrorsEnum.INVALID_REASON);
 
         return next();
     } catch (err) {

--- a/src/tornadoArticles/middlewares/publishArticle.validate.js
+++ b/src/tornadoArticles/middlewares/publishArticle.validate.js
@@ -42,6 +42,20 @@ async function publishArticleValidate(req, res, next) {
         if (content === null)
             return next(GlobalErrorsEnum.MISSING_FIELD("content"));
 
+        // There is a small issue in multipart/form-data. I will solve it with less overhead but with little redundant code
+        // This code will help when user publish an article without images so client can send request with content-type: application/json
+        if (typeof categories === "string") categories = [categories];
+        if (typeof tags === "string") tags = [tags];
+        if (typeof topics === "string") topics = [topics];
+        if (typeof isPrivate === "string") {
+            isPrivate =
+                isPrivate.toLowerCase() === "true"
+                    ? true
+                    : isPrivate.toLowerCase() === "false"
+                    ? true
+                    : null; // null to throw error later :3
+        }
+
         const ArticleSchema = object({
             title: string(),
             content: string(),

--- a/src/tornadoPlatform/controllers/deleteAction.js
+++ b/src/tornadoPlatform/controllers/deleteAction.js
@@ -1,0 +1,24 @@
+import ModeratorActionService from '../services/moderatorActionService.js';
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function deleteAction(req, res, next) {
+    try {
+        const {actionId} = req?.params;
+
+        // This will throw an error if not exists
+        await ModeratorActionService.deleteAction(actionId);
+
+        return res.status(200).json({
+            success: true,
+            message: "Action record deleted successfully"
+        })
+    } catch (err) {
+        next(err);
+    }
+}
+
+export default deleteAction;

--- a/src/tornadoPlatform/controllers/deleteNullRecords.js
+++ b/src/tornadoPlatform/controllers/deleteNullRecords.js
@@ -1,0 +1,57 @@
+import generateDateBefore from "../../../util/generateDateBefore.js";
+import ModeratorActionService from "../services/moderatorActionService.js";
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function deleteNullRecords(req, res, next) {
+    try {
+        // Check deleteNullRecords.validate.js to know what are those fields
+        const { pastDuration, firstDate, secondDate } =
+            req?.validatedQuery ?? {};
+
+        // The validator middleware will force one to pass either pastDuration or date range
+        if (pastDuration !== null) {
+            let date = new Date();
+            if (pastDuration.toLowerCase() === "now") {
+                const deletedCounts =
+                    await ModeratorActionService.deleteAllNullRecords();
+
+                return res.status(200).json({
+                    success: true,
+                    message: `deleted ${deletedCounts} record(s) successfully`,
+                    deletedCounts,
+                });
+            }
+
+            // Parse the passed duration
+            date = generateDateBefore(pastDuration, { firstMoment: true });
+            const deletedCounts =
+                await ModeratorActionService.deleteNullRecordInPast(date);
+
+            return res.status(200).json({
+                success: true,
+                message: `deleted ${deletedCounts} record(s) successfully`,
+                deletedCounts,
+            });
+        }
+
+        const deletedCounts =
+            await ModeratorActionService.deleteNullRecordsBetweeen(
+                firstDate,
+                secondDate
+            );
+
+        return res.status(200).json({
+            success: true,
+            message: `deleted ${deletedCounts} record(s) successfully`,
+            deletedCounts
+        });
+    } catch (err) {
+        next(err);
+    }
+}
+
+export default deleteNullRecords;

--- a/src/tornadoPlatform/controllers/getActions.js
+++ b/src/tornadoPlatform/controllers/getActions.js
@@ -1,0 +1,27 @@
+import ModeratorActionService from "../services/moderatorActionService.js";
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function getActions(req, res, next) {
+    try {
+        const { lastEntryId, limit } = req?.validatedQuery;
+
+        const actions = await ModeratorActionService.getActions(
+            lastEntryId,
+            limit
+        );
+
+        return res.status(200).json({
+            success: true,
+            data: actions,
+            lastEntryId: actions?.at?.(-1)?.id ?? null, // Get last entry id or null when there is no more actions
+        });
+    } catch (err) {
+        next(err);
+    }
+}
+
+export default getActions;

--- a/src/tornadoPlatform/controllers/getActionsByUser.js
+++ b/src/tornadoPlatform/controllers/getActionsByUser.js
@@ -1,0 +1,29 @@
+import ModeratorActionService from "../services/moderatorActionService.js";
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function getActionsByUser(req, res, next) {
+    try {
+        const { lastEntryId, limit } = req?.validatedQuery;
+        const { userId } = req?.params;
+
+        const actions = await ModeratorActionService.getActions(
+            lastEntryId,
+            limit,
+            userId
+        );
+
+        return res.status(200).json({
+            success: true,
+            data: actions,
+            lastEntryId: actions?.at?.(-1)?.id ?? null, // Get last entry id or null when there is no more actions
+        });
+    } catch (err) {
+        next(err);
+    }
+}
+
+export default getActionsByUser;

--- a/src/tornadoPlatform/controllers/publishAction.js
+++ b/src/tornadoPlatform/controllers/publishAction.js
@@ -1,0 +1,31 @@
+import ModeratorActionService from "../services/moderatorActionService.js";
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function publishAction(req, res, next) {
+    try {
+        const { userId, userName, userEmail, actionType, duration, reason } =
+            req?.body;
+
+        const action = await ModeratorActionService.publishAction(
+            userId,
+            userName,
+            userEmail,
+            actionType,
+            duration,
+            reason
+        );
+
+        return res.status(200).json({
+            success: true,
+            data: action,
+        });
+    } catch (err) {
+        next(err);
+    }
+}
+
+export default publishAction;

--- a/src/tornadoPlatform/controllers/updateAction.js
+++ b/src/tornadoPlatform/controllers/updateAction.js
@@ -1,0 +1,31 @@
+import ModeratorActionService from "../services/moderatorActionService.js";
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function updateAction(req, res, next) {
+    try {
+        // This endpoint can use the same validator for publishing an action
+        const { actionType, duration, reason } = req?.body;
+
+        const { actionId } = req?.params;
+
+        const action = await ModeratorActionService.updateAction(
+            actionId,
+            actionType,
+            duration,
+            reason
+        );
+
+        return res.status(200).json({
+            success: true,
+            data: action,
+        });
+    } catch (err) {
+        next(err);
+    }
+}
+
+export default updateAction;

--- a/src/tornadoPlatform/middlewares/deleteNullRecords.validate.js
+++ b/src/tornadoPlatform/middlewares/deleteNullRecords.validate.js
@@ -1,0 +1,102 @@
+import { date, object, string, ZodError } from "zod/v4";
+import APIError from "../../../util/APIError.js";
+import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
+
+class ErrorsEnum {
+    static INCORRECT_DECISION = new APIError(
+        "Provide either 'pastDuration' to delete record for last passed duration. or both 'firstDate' and 'lastDate' to delete records between provided dates",
+        400,
+        "VALIDATION_ERRORs"
+    );
+
+    static INCORRECT_DATE_RANGE = new APIError(
+        "Invalid date range. 'firstDate' must be less than 'secondDate'",
+        400,
+        "VALIDATION_ERROR"
+    );
+
+    static INVALID_DURATION = () => {
+        const cachedErr = GlobalErrorsEnum.INVALID_DATATYPE(
+            "pastDuration",
+            "string"
+        );
+
+        cachedErr.additionalData.hint =
+            "The duration may have spaces like '1 month' try to remove the space or check if it passed as URL Encoded. if you are using JavaScript URLSearchParams may help";
+        return cachedErr;
+    };
+
+    static INVALID_DATE = (path) => {
+        const cachedErr = GlobalErrorsEnum.INVALID_DATATYPE(path, "Date");
+
+        cachedErr.additionalData.hint =
+            `The ${path} must be string date. if you are using ISO date string check if it passed as URL Encoded. if you are using JavaScript URLSearchParams may help`;
+        return cachedErr;
+    };
+}
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function deleteNullRecordsValidate(req, res, next) {
+    try {
+        // This route when the moderators want to clear the data from null userIDs
+        // Or in another word the deleted user accounts
+
+        // Maybe he want to delete reords for the last month. or maybe year. or now
+
+        // First date and second date is to set a date range to delete all null records between them.
+        // Note that the first must be less than second
+        const {
+            pastDuration = null,
+            firstDate = null,
+            secondDate = null,
+        } = req?.query ?? {};
+
+        // One decision accepted. Either pastDuration or both first and second date
+        if (
+            (pastDuration !== null &&
+                (firstDate !== null || secondDate !== null)) ||
+            (pastDuration === null &&
+                (firstDate === null || secondDate === null))
+        )
+            return next(ErrorsEnum.INCORRECT_DECISION);
+
+        const Query = object({
+            pastDuration: string().nullable(),
+            firstDate: date().nullable(),
+            secondDate: date().nullable(),
+        });
+
+        req.validatedQuery = Query.parse({
+            pastDuration,
+            firstDate: new Date(firstDate),
+            secondDate: new Date(secondDate),
+        });
+
+        // After correctly parsing the query. check if first and second is correct logically
+        if (firstDate > secondDate)
+            return next(ErrorsEnum.INCORRECT_DATE_RANGE);
+
+        return next();
+    } catch (err) {
+        if (err instanceof ZodError) {
+            let code = err.issues[0].code;
+            let path = err.issues[0].path[0];
+
+            if (code === "invalid_type" && path === "pastDuration")
+                return next(ErrorsEnum.INVALID_DURATION());
+
+            if (
+                code === "invalid_type" &&
+                ["firstDate", "secondDate"].includes(path)
+            )
+                return next(ErrorsEnum.INVALID_DATE(path));
+        }
+        next(err);
+    }
+}
+
+export default deleteNullRecordsValidate;

--- a/src/tornadoPlatform/middlewares/getActions.validate.js
+++ b/src/tornadoPlatform/middlewares/getActions.validate.js
@@ -1,0 +1,42 @@
+import { int, object, string, ZodError } from "zod/v4";
+import { MAX_RESULTS, MIN_RESULTS } from "../../../config/settings.js";
+import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function getActionsValidate(req, res, next) {
+    try {
+        const { lastEntryId = "9223372036854775807", limit = MIN_RESULTS } =
+            req?.query ?? {};
+
+        const Query = object({
+            limit: int(),
+            lastEntryId: string().regex(/^\d+$/),
+        });
+
+        req.validatedQuery = Query.parse({
+            lastEntryId,
+            limit: Number(limit),
+        });
+
+        if (Number(limit) < 0 || Number(limit) > MAX_RESULTS)
+            return next(GlobalErrorsEnum.INVALID_LIMIT("limit", MAX_RESULTS));
+
+        return next();
+    } catch (err) {
+        if (err instanceof ZodError) {
+            let code = err.issues[0].code;
+            let path = err.issues[0].path[0];
+
+            if (code === "invalid_type" || code === "invalid_format")
+                return next(GlobalErrorsEnum.INVALID_DATATYPE(path, "integer"));
+        }
+
+        next(err);
+    }
+}
+
+export default getActionsValidate;

--- a/src/tornadoPlatform/middlewares/publishAction.validate.js
+++ b/src/tornadoPlatform/middlewares/publishAction.validate.js
@@ -1,0 +1,87 @@
+import { email, object, string, ZodError } from "zod/v4";
+import APIError from "../../../util/APIError.js";
+import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
+import { MODERATOR_ACTIONS } from "../../../config/settings.js";
+
+class ErrorsEnum {
+    static ALL_REQUIRED = new APIError(
+        "Provide these fields (userId, userName, userEmail, reason, actionType)",
+        400,
+        "VALIDATION_ERROR"
+    );
+}
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function publishActionValidate(req, res, next) {
+    try {
+        const {
+            userId = null,
+            userName = null,
+            userEmail = null,
+            actionType = null,
+            duration = null,
+            reason = null,
+        } = req?.body ?? {};
+
+        // TODO: when implements notifications notify the user
+
+        // Chose what must not be null
+        if (
+            userId === null ||
+            userName === null ||
+            userEmail === null ||
+            reason === null ||
+            actionType === null
+        )
+            return next(ErrorsEnum.ALL_REQUIRED);
+
+        const Query = object({
+            userId: string().regex(/^\d+$/),
+            userName: string(),
+            userEmail: email().trim(),
+            actionType: string(),
+            duration: string().nullable(),
+            reason: string(),
+        });
+
+        Object.assign(
+            req.body,
+            Query.parse({
+                userId: String(userId),
+                userName,
+                userEmail,
+                actionType: actionType?.toLowerCase?.(),
+                duration,
+                reason,
+            })
+        );
+
+        if(!MODERATOR_ACTIONS.includes(actionType))
+            return next(GlobalErrorsEnum.UNRECOGNIZED_ACTION_TYPE)
+
+        if (email.length > 254) return next(GlobalErrorsEnum.TOO_LONG_EMAIL);
+
+        return next();
+    } catch (err) {
+        if (err instanceof ZodError) {
+            let code = err.issues[0].code;
+            let path = err.issues[0].path[0];
+
+            if (
+                (code === "invalid_type" || code === "invalid_format") &&
+                path === "userId"
+            )
+                return next(GlobalErrorsEnum.INVALID_BIGINT_ID("userId"));
+
+            if (code === "invalid_type")
+                return next(GlobalErrorsEnum.INVALID_DATATYPE(path, "string"));
+        }
+        next(err);
+    }
+}
+
+export default publishActionValidate;

--- a/src/tornadoPlatform/middlewares/updateAction.validate.js
+++ b/src/tornadoPlatform/middlewares/updateAction.validate.js
@@ -1,0 +1,67 @@
+import { object, string, ZodError } from "zod/v4";
+import { MODERATOR_ACTIONS } from "../../../config/settings.js";
+import APIError from "../../../util/APIError.js";
+import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
+import isNull from "../../../util/isNull.js";
+
+class ErrorsEnum {
+    static ONE_FIELD_REQUIRED = new APIError(
+        "Provide one of these fields (reason, actionType, duration)",
+        400,
+        "VALIDATION_ERROR"
+    );
+}
+
+/**
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+async function updateActionValidate(req, res, next) {
+    try {
+        const {
+            actionType = undefined,
+            duration = undefined,
+            reason = undefined,
+        } = req?.body ?? {};
+
+        if (
+            reason === undefined &&
+            actionType === undefined &&
+            duration === undefined
+        )
+            return next(ErrorsEnum.ONE_FIELD_REQUIRED);
+
+        const Query = object({
+            actionType: string().optional(),
+            duration: string().nullable().optional(),
+            reason: string().optional(),
+        });
+
+        Object.assign(
+            req.body,
+            Query.parse({
+                actionType: actionType?.toLowerCase?.(),
+                duration,
+                reason,
+            })
+        );
+
+        if (!isNull(actionType) && !MODERATOR_ACTIONS.includes(actionType))
+            return next(GlobalErrorsEnum.UNRECOGNIZED_ACTION_TYPE);
+
+        return next();
+    } catch (err) {
+        if (err instanceof ZodError && err.issues[0].code === "invalid_type")
+            return next(
+                GlobalErrorsEnum.INVALID_DATATYPE(
+                    err.issues[0].path[0],
+                    "string"
+                )
+            );
+
+        next(err);
+    }
+}
+
+export default updateActionValidate;

--- a/src/tornadoPlatform/models/moderatorAction.js
+++ b/src/tornadoPlatform/models/moderatorAction.js
@@ -1,0 +1,93 @@
+import { DataTypes, Model } from "sequelize";
+import { sequelize } from "../../../config/sequelize.js";
+import { MODERATOR_ACTIONS } from "../../../config/settings.js";
+import { generateSnowFlakeIdPlatform } from "../../../config/snowFlake.js";
+import APIError from "../../../util/APIError.js";
+import isNull from "../../../util/isNull.js";
+
+class ModeratorAction extends Model {}
+
+ModeratorAction.init(
+    {
+        id: {
+            type: DataTypes.BIGINT,
+            defaultValue: generateSnowFlakeIdPlatform,
+            primaryKey: true,
+        },
+        userId: {
+            type: DataTypes.BIGINT,
+            allowNull: true,
+            references: {
+                model: "Users",
+                key: "id",
+            },
+            onDelete: "SET NULL",
+            onUpdate: "CASCADE",
+        },
+        userName: {
+            // Repeated this because you may delete an account so it will be deleted so maybe the admin want to keep data in the platform
+            type: DataTypes.STRING(150),
+            allowNull: false,
+        },
+        userEmail: {
+            // Same reason here. And this isn't unique because the same user may get banned twice
+            type: DataTypes.STRING(254),
+            allowNull: false,
+            validate: {
+                isEmail: true,
+            },
+        },
+        actionType: {
+            type: DataTypes.ENUM(...MODERATOR_ACTIONS), // When you get more actions types add them here
+            allowNull: false,
+        },
+        duration: {
+            type: DataTypes.STRING(100), // Like ban for 2 days
+            allowNull: true, // When deleting account there is no duration or can be permanent
+        },
+        reason: {
+            type: DataTypes.STRING(350), // Explain why user X got (ban, delete account) that may help in data analysis
+            allowNull: false, // You must provide a reason
+            validate: {
+                isBigEnough(reason) {
+                    if (reason.length < 4)
+                        throw new APIError(
+                            "The reason must be at least 4 characters length",
+                            400,
+                            "VALIDATION_ERROR"
+                        );
+                },
+            },
+        },
+    },
+    {
+        sequelize,
+        createdAt: true,
+        updatedAt: false,
+        // TODO: analyze and add the index for userId may help when user with id X break rules many times and moderator want to check if he has a history
+        hooks: {
+            beforeValidate(instance) {
+                if (!isNull(instance.dataValues.reason))
+                    instance.dataValues.reason =
+                        instance.dataValues.reason.trim();
+
+                if (!isNull(instance.dataValues.userName))
+                    instance.dataValues.userName =
+                        instance.dataValues.userName.trim();
+                // User email is trimmed. check publishAction.validate.js and the other publisher will be automated from user table
+
+                if (!isNull(instance.dataValues.actionType))
+                    instance.dataValues.actionType =
+                        instance.dataValues.actionType.trim().toLowerCase();
+
+                // This field is nullable
+                if (!isNull(instance.dataValues.duration))
+                    instance.dataValues.duration = instance.dataValues.duration
+                        .trim()
+                        .toLowerCase();
+            },
+        },
+    }
+);
+
+export default ModeratorAction;

--- a/src/tornadoPlatform/routes/moderatorActionRoutes.js
+++ b/src/tornadoPlatform/routes/moderatorActionRoutes.js
@@ -1,0 +1,72 @@
+import { Router } from "express";
+
+import deleteAction from "../controllers/deleteAction.js";
+import getActions from "../controllers/getActions.js";
+import getActionsByUser from "../controllers/getActionsByUser.js";
+import publishAction from "../controllers/publishAction.js";
+import updateAction from "../controllers/updateAction.js";
+import getActionsValidate from "../middlewares/getActions.validate.js";
+
+import isAuthenticated from "../../../publicMiddlewares/isAuthenticated.js";
+import isModerator from "../../../publicMiddlewares/isModerator.js";
+import deleteNullRecords from "../controllers/deleteNullRecords.js";
+import publishActionValidate from "../middlewares/publishAction.validate.js";
+import updateActionValidate from "../middlewares/updateAction.validate.js";
+import deleteNullRecordsValidate from "../middlewares/deleteNullRecords.validate.js";
+
+const moderatorActionRoutes = Router();
+
+// Moderators can get all actions
+moderatorActionRoutes.get(
+    "/moderator-actions",
+    isAuthenticated,
+    isModerator,
+    getActionsValidate,
+    getActions
+);
+
+// Moderators can publish an action like user warning or add categories. That up to them
+moderatorActionRoutes.post(
+    "/moderator-actions",
+    isAuthenticated,
+    isModerator,
+    publishActionValidate,
+    publishAction
+);
+
+// Moderators can delete rows where userId is null
+moderatorActionRoutes.delete(
+    "/moderator-actions",
+    isAuthenticated,
+    isModerator,
+    deleteNullRecordsValidate,
+    deleteNullRecords
+);
+
+// Moderators can delete some actions
+moderatorActionRoutes.delete(
+    "/moderator-actions/:actionId",
+    isAuthenticated,
+    isModerator,
+    deleteAction
+);
+
+// Moderators can see `History` or actions take for user with x ID
+moderatorActionRoutes.get(
+    "/moderator-actions/:userId",
+    isAuthenticated,
+    isModerator,
+    getActionsValidate,
+    getActionsByUser
+);
+
+// Moderators can update some fields of actions
+moderatorActionRoutes.patch(
+    "/moderator-actions/:actionId",
+    isAuthenticated,
+    isModerator,
+    updateActionValidate,
+    updateAction
+);
+
+export default moderatorActionRoutes;

--- a/src/tornadoPlatform/services/moderatorActionService.js
+++ b/src/tornadoPlatform/services/moderatorActionService.js
@@ -1,0 +1,269 @@
+import { Op } from "sequelize";
+import { sequelize } from "../../../config/sequelize.js";
+import APIError from "../../../util/APIError.js";
+import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
+import ModeratorAction from "../models/moderatorAction.js";
+
+class ErrorsEnum {
+    static ACTION_NOT_FOUND = new APIError(
+        "The action is not found or already deleted",
+        404,
+        "ACTION_NOT_FOUND"
+    );
+}
+
+class ModeratorActionService {
+    static async addBanRecord(
+        userId,
+        userName,
+        userEmail,
+        duration,
+        reason,
+        transaction = null
+    ) {
+        // When the user doesn't pass the transaction create it by my self
+        let passedTransaction = transaction !== null;
+
+        if (!passedTransaction) {
+            transaction = await sequelize.transaction();
+        }
+
+        try {
+            await ModeratorAction.create(
+                {
+                    userId,
+                    userName,
+                    userEmail,
+                    actionType: "ban",
+                    reason,
+                    duration,
+                },
+                {
+                    transaction,
+                    validate: true,
+                }
+            );
+
+            // If the transaction is passed by the developer let him manage it
+            if (!passedTransaction) await transaction.commit();
+            return true;
+        } catch (err) {
+            if (!passedTransaction) await transaction.rollback();
+            throw err;
+        }
+    }
+
+    static async addDeleteUserRecord(
+        userName,
+        userEmail,
+        reason,
+        transaction = null
+    ) {
+        // When the user doesn't pass the transaction create it by my self
+        let passedTransaction = transaction !== null;
+
+        if (!passedTransaction) {
+            transaction = await sequelize.transaction();
+        }
+
+        try {
+            await ModeratorAction.create(
+                {
+                    userId: null, // Because the user will be deleted
+                    userName,
+                    userEmail,
+                    actionType: "delete account",
+                    reason,
+                    duration: "permanent",
+                },
+                {
+                    transaction,
+                    validate: true,
+                }
+            );
+
+            // If the transaction is passed by the developer let him manage it
+            if (!passedTransaction) await transaction.commit();
+
+            return true;
+        } catch (err) {
+            if (!passedTransaction) await transaction.rollback();
+            throw err;
+        }
+    }
+
+    static async addDeleteArticleRecord(
+        userId,
+        userEmail,
+        userName,
+        reason,
+        transaction
+    ) {
+        // When the user doesn't pass the transaction create it by my self
+        let passedTransaction = transaction !== null;
+
+        if (!passedTransaction) {
+            transaction = await sequelize.transaction();
+        }
+
+        try {
+            await ModeratorAction.create(
+                {
+                    userId,
+                    userName,
+                    userEmail,
+                    actionType: "delete article",
+                    duration: "permanent",
+                    reason,
+                },
+                { transaction, validate: true }
+            );
+
+            // If the transaction is passed by the developer let him manage it
+            if (!passedTransaction) await transaction.commit();
+
+            return true;
+        } catch (err) {
+            if (!passedTransaction) await transaction.rollback();
+            throw err;
+        }
+    }
+
+    static async getActions(lastEntryId, limit, userId = null) {
+        try {
+            const actions = await ModeratorAction.findAll({
+                where: {
+                    ...(userId !== null ? { userId } : {}),
+                    id: {
+                        [Op.lt]: lastEntryId,
+                    },
+                },
+                limit,
+                order: [["id", "DESC"]],
+            });
+
+            return actions;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    static async deleteAction(actionId) {
+        try {
+            if (!/^\d+$/.test(actionId))
+                throw GlobalErrorsEnum.INVALID_BIGINT_ID("action id");
+
+            const rowDeleted = await ModeratorAction.destroy({
+                where: { id: actionId },
+            });
+
+            if (rowDeleted === 0) throw ErrorsEnum.ACTION_NOT_FOUND;
+
+            return rowDeleted;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    static async publishAction(
+        userId,
+        userName,
+        userEmail,
+        actionType,
+        duration,
+        reason
+    ) {
+        try {
+            const action = await ModeratorAction.create(
+                {
+                    userId,
+                    userName,
+                    userEmail,
+                    actionType,
+                    duration,
+                    reason,
+                },
+                {
+                    returning: true,
+                }
+            );
+
+            return action;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    static async updateAction(id, actionType, duration, reason) {
+        try {
+            const [, action] = await ModeratorAction.update(
+                {
+                    duration,
+                    actionType,
+                    reason,
+                },
+                {
+                    where: {
+                        id,
+                    },
+                    returning: true,
+                    validate: true,
+                }
+            );
+
+            if (action === null) throw ErrorsEnum.ACTION_NOT_FOUND;
+
+            return action[0];
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    static async deleteAllNullRecords() {
+        try {
+            const deletedCounts = await ModeratorAction.destroy({
+                where: { userId: null },
+            });
+
+            return deletedCounts;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    static async deleteNullRecordInPast(durationDate) {
+        try {
+            const deletedCounts = await ModeratorAction.destroy({
+                where: {
+                    userId: null,
+                    createdAt: {
+                        [Op.gte]: durationDate, // from that let's say month till now
+                    },
+                },
+            });
+
+            return deletedCounts;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    static async deleteNullRecordsBetweeen(firstDate, secondDate) {
+        try {
+            const deletedCounts = await ModeratorAction.destroy({
+                where: {
+                    userId: null,
+                    createdAt: {
+                        [Op.between]: [firstDate, secondDate], // from that let's say month till now
+                    },
+                },
+            });
+
+            return deletedCounts;
+        } catch (err) {
+            throw err;
+        }
+    }
+}
+
+export default ModeratorActionService;

--- a/src/tornadoUser/controllers/getFollowers.js
+++ b/src/tornadoUser/controllers/getFollowers.js
@@ -12,8 +12,8 @@ async function getFollowers(req, res, next) {
 
         const { limit, entryItemName, getAfter } = req?.validatedQuery;
 
-        // This will throw an error if the user doesn't exists
-        await TornadoUserService.getUserById(userId);
+        // This will throw an error if the user doesn't exist
+        await TornadoUserService.isUserExists(userId);
 
         const followers = await FollowingService.getFollowers(
             userId,

--- a/src/tornadoUser/controllers/getFollowings.js
+++ b/src/tornadoUser/controllers/getFollowings.js
@@ -11,8 +11,8 @@ async function getFollowings(req, res, next) {
         const { userId } = req?.params;
         const { limit, entryItemName, getAfter } = req?.validatedQuery;
 
-        // This will throw an error if the user doesn't exists
-        await TornadoUserService.getUserById(userId);
+        // This will throw an error if the user doesn't exist
+        await TornadoUserService.isUserExists(userId);
 
         const followings = await FollowingService.getFollowings(
             userId,

--- a/src/tornadoUser/middlewares/adminBanUser.validate.js
+++ b/src/tornadoUser/middlewares/adminBanUser.validate.js
@@ -2,9 +2,15 @@ import { object, string, ZodError } from "zod/v4";
 import APIError from "../../../util/APIError.js";
 import GlobalErrorsEnum from "../../../util/globalErrorsEnum.js";
 
-class ErrorEnum {
+class ErrorsEnum {
     static INVALID_REASON_LENGTH = new APIError(
         "The reason should be at least 20 characters length",
+        400,
+        "VALIDATION_ERROR"
+    );
+
+    static ALL_REASONS_REQUIRED = new APIError(
+        "Provide both 'userReason' and 'reason'",
         400,
         "VALIDATION_ERROR"
     );
@@ -17,25 +23,35 @@ class ErrorEnum {
  */
 async function adminBanUserValidate(req, res, next) {
     try {
-        const { banFor = "1 week", reason = null } = req?.body ?? {};
+        const {
+            banFor = "1 week",
+            reason = null,
+            userReason = null,
+        } = req?.body ?? {};
 
-        if (reason === null)
-            return next(GlobalErrorsEnum.MISSING_FIELD("reason"));
+        if (reason === null || userReason === null)
+            return next(ErrorsEnum.ALL_REASONS_REQUIRED);
 
         const BanSchema = object({
             banFor: string().trim(),
-            reason: string().trim().min(20),
+            reason: string(),
+            userReason: string(),
         });
-        
+
         Object.assign(
             req.body,
             BanSchema.parse({
                 banFor,
                 reason,
+                userReason
             })
         );
 
-        next();
+        // Check user reason length
+        if (userReason.length > 300 && userReason.length < 4)
+            return next(GlobalErrorsEnum.INVALID_REASON);
+
+        return next();
     } catch (err) {
         if (err instanceof ZodError) {
             let code = err.issues[0].code;
@@ -46,7 +62,7 @@ async function adminBanUserValidate(req, res, next) {
                 return next(GlobalErrorsEnum.INVALID_DATATYPE(path, expected));
 
             if (code === "too_small")
-                return next(ErrorEnum.INVALID_REASON_LENGTH);
+                return next(ErrorsEnum.INVALID_REASON_LENGTH);
         }
         next(err);
     }

--- a/src/tornadoUser/routes/userRoutes.js
+++ b/src/tornadoUser/routes/userRoutes.js
@@ -12,19 +12,20 @@ import getFollowings from "../controllers/getFollowings.js";
 import getPreferredCategories from "../controllers/getPreferredCategories.js";
 import getPreferredTopics from "../controllers/getPreferredTopics.js";
 import getUserProfile from "../controllers/getUserProfile.js";
+import removePreferredCategories from "../controllers/removePreferredCategories.js";
 import removePreferredTopics from "../controllers/removePreferredTopics.js";
 import searchForUsers from "../controllers/searchForUsers.js";
 import setPreferredCategories from "../controllers/setPreferredCategories.js";
 import setPreferredTopics from "../controllers/setPreferredTopics.js";
 import unfollowUser from "../controllers/unfollowUser.js";
 import updateCookiesAccess from "../controllers/updateCookiesAccess.js";
-import removePreferredCategories from "../controllers/removePreferredCategories.js";
 
 // Middlewares
 import downloadProfilePic from "../../../publicMiddlewares/downloadProfilePic.js";
 import isAdmin from "../../../publicMiddlewares/isAdmin.js";
 import isAuthenticated from "../../../publicMiddlewares/isAuthenticated.js";
 import isLoggedIn from "../../../publicMiddlewares/isLoggedIn.js";
+import isModerator from "../../../publicMiddlewares/isModerator.js";
 import adminBanUserValidate from "../middlewares/adminBanUser.validate.js";
 import changeNameValidate from "../middlewares/changeName.validate.js";
 import editBriefValidate from "../middlewares/editBrief.validate.js";
@@ -136,11 +137,11 @@ userRoutes.get(
     adminGetUsers
 );
 
-// Admin can ban users from publishing articles
+// Moderator can ban users from publishing articles
 userRoutes.post(
     "/users/ban/:userId",
     isAuthenticated,
-    isAdmin,
+    isModerator,
     adminBanUserValidate,
     adminBanUser
 );

--- a/util/generateDateBefore.js
+++ b/util/generateDateBefore.js
@@ -1,13 +1,23 @@
 import parseStrPeriod from "./parseStrPeriod.js";
 
 /**
+ * @typedef Options
+ * @property {Date} date the date you want start at. Default is current time
+ * @property {boolean} firstMoment Wether to set the date at first moment in the result date. Default false
+ */
+
+/**
  * Generate a date before given period
  * @param {string} strPeriod The period you want
+ * @param {Options}
  * @returns {Date} The date before the given period
  * @example
  * const dateBeforeMonth = generateDateBefore('1 month', new Date('6/21/2025')); // new Date('5/21/2025')
  */
-export default function generateDateBefore(strPeriod, date = new Date()) {
+export default function generateDateBefore(
+    strPeriod,
+    { date = new Date(), firstMoment = false }
+) {
     const { keyword, period } = parseStrPeriod(strPeriod);
 
     // To be able to decrement
@@ -35,5 +45,11 @@ export default function generateDateBefore(strPeriod, date = new Date()) {
             break;
     }
 
-    return new Date(date.getTime() - time);
+    let res = new Date(date.getTime() - time);
+
+    if(firstMoment) {
+        res.setHours(0 ,0, 0, 0) // Set it to the very first moment
+    }
+
+    return res;
 }

--- a/util/globalErrorsEnum.js
+++ b/util/globalErrorsEnum.js
@@ -2,6 +2,7 @@ import {
     MAX_CATEGORIES_ARTICLE_COUNT,
     MAX_TAGS_ARTICLE_COUNT,
     MAX_TOPICS_ARTICLE_COUNT,
+    MODERATOR_ACTIONS,
 } from "../config/settings.js";
 import APIError from "./APIError.js";
 
@@ -65,6 +66,12 @@ export default class GlobalErrorsEnum {
             400,
             "INVALID_IMAGE_TYPE"
         );
+
+    static INVALID_REASON = new APIError(
+        "The reason must be between 4 characters and 300 maximum",
+        400,
+        "VALIDATION_ERROR"
+    );
 
     // For Auth
     static MISSING_REFRESH_TOKEN = new APIError(
@@ -181,4 +188,13 @@ export default class GlobalErrorsEnum {
             404,
             "ARTICLE_NOT_FOUND"
         );
+
+    //// For moderator actions
+    static UNRECOGNIZED_ACTION_TYPE = new APIError(
+        `action type isn't recognized. the types are (${MODERATOR_ACTIONS.join(
+            ", "
+        )})`,
+        400,
+        "VALIDATION_ERROR"
+    );
 }

--- a/util/isNull.js
+++ b/util/isNull.js
@@ -1,0 +1,8 @@
+/**
+ * check if the passed token is undefined or null
+ * @param {any} token
+ * @returns {boolean}
+ */
+export default function isNull(token) {
+    return token === null || token === undefined;
+}

--- a/util/parseStrPeriod.js
+++ b/util/parseStrPeriod.js
@@ -1,5 +1,6 @@
 class WrongPeriod extends Error {
     constructor(message) {
+        super(message);
         this.message = message;
     }
 }


### PR DESCRIPTION
# Tornado Platform
this is the name of the new module in the project. It's used primarily for any operation that related either to the platform or the users. Something like Support, Terms and others goes under the umbrella of this module. and for sure anything will help moderators and admin for improving Tornado Platform will be inserted here such as **most searched category for last month or a date range**.

## Moderators Actions
there is a term in the platform. which is if the user let's say got a ban for 1 week.  after the ban be washed away, he has a **penalty period** which is simply if he broke the rules again in X days his/her account will be deleted, or he will get longer ban for example.

Whether the first option taken or the second. How should the moderators know the user's history ?

**answer:** By this module. Some part of it is automated. Like when user X get banned automatically the action will be inserted in **ModeratorActions** model. And for sure the moderator can publish a warning for that user before takes any action for that he can insert an **Action**.

**Important Note:** the name `Reports` is reserved for another module which is responsible of reporting for an article. And **ModeratorAction** module is meant for any action take for **Tornado Users** not any action taken by them. For that I will try to add another module in the future.